### PR TITLE
lerc 4.0.0

### DIFF
--- a/recipe/add-missing-include.patch
+++ b/recipe/add-missing-include.patch
@@ -1,0 +1,21 @@
+From 1fc73694263f53cf029c8cac2e632170880f56d4 Mon Sep 17 00:00:00 2001
+From: Thomas Maurer <tmaurer@esri.com>
+Date: Wed, 8 Nov 2023 12:54:35 -0800
+Subject: [PATCH] add missing include
+
+---
+ src/LercLib/fpl_Compression.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/LercLib/fpl_Compression.cpp b/src/LercLib/fpl_Compression.cpp
+index bea9483..22773dd 100644
+--- a/src/LercLib/fpl_Compression.cpp
++++ b/src/LercLib/fpl_Compression.cpp
+@@ -27,6 +27,7 @@ Original coding 2021 Yuriy Yakimenko
+ #include <assert.h>
+ #include <cmath>
+ #include <cstring>
++#include <climits>
+ 
+ USING_NAMESPACE_LERC
+ 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir cmake_build
 cd cmake_build
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,20 @@
 {% set name = "lerc" %}
-{% set version = "3.0" %}
+{% set version = "4.0.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/Esri/lerc/archive/v{{ version }}.tar.gz
-  sha256: 8c0148f5c22d823eff7b2c999b0781f8095e49a7d3195f13c68c5541dd5740a1
+  # temporarily, version starts with js_*, remove it when a new version is available.
+  # v4.0.4 has improvements in the c++ code.
+  url: https://github.com/Esri/lerc/archive/js_v{{ version }}.tar.gz
+  sha256: 1dc090218387ab8ca615eefd844207be64454e37868b396f3e965ed0dcf83947
   # CMakeLists.txt taken from master, and adapted for better compatibility
   # PR made: https://github.com/Esri/lerc/pull/128
+  patches:
+    # see https://github.com/Esri/lerc/issues/253
+    - add-missing-include.patch
 
 build:
   number: 0
@@ -23,8 +28,10 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make  # [unix]
-    - ninja  # [win]
-  #host:
+    - ninja-base  # [win]
+    - m2-patch    # [win]
+    - patch       # [unix]
+  host:
     # TODO: add support for
     # gdal
     # geotiff
@@ -32,10 +39,14 @@ requirements:
 test:
   commands:
     - if not exist %LIBRARY_INC%\Lerc_types.h exit 1  # [win]
+    - if not exist %LIBRARY_INC%\Lerc_c_api.h exit 1  # [win]
     - if not exist %LIBRARY_BIN%\Lerc.dll exit 1      # [win]
     - if not exist %LIBRARY_LIB%\Lerc.lib exit 1      # [win]
+    - if not exist %LIBRARY_LIB%\pkgconfig\Lerc.pc exit 1      # [win]
     - test -f ${PREFIX}/lib/libLerc${SHLIB_EXT}       # [unix]
     - test -f ${PREFIX}/include/Lerc_types.h          # [unix]
+    - test -f ${PREFIX}/include/Lerc_c_api.h          # [unix]
+    - test -f ${PREFIX}/lib/pkgconfig/Lerc.pc         # [unix]
 
 about:
   home: https://github.com/Esri/lerc
@@ -43,7 +54,6 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: LERC - Limited Error Raster Compression
-
   description: |
     LERC is an open-source image or raster format which
     supports rapid encoding and decoding for any pixel type
@@ -51,6 +61,8 @@ about:
     error per pixel while encoding, so the precision of the
     original input image is preserved (within user defined
     error bounds).
+  dev_url: https://github.com/Esri/lerc
+  doc_url: https://github.com/Esri/lerc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Esri/lerc/archive/v{{ version }}.tar.gz
-  sha256: 1dc090218387ab8ca615eefd844207be64454e37868b396f3e965ed0dcf83947
+  sha256: 91431c2b16d0e3de6cbaea188603359f87caed08259a645fd5a3805784ee30a0
   # CMakeLists.txt taken from master, and adapted for better compatibility
   # PR made: https://github.com/Esri/lerc/pull/128
   patches:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,12 @@
 {% set name = "lerc" %}
-{% set version = "4.0.4" %}
+{% set version = "4.0.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # temporarily, version starts with js_*, remove it when a new version is available.
-  # v4.0.4 has improvements in the c++ code.
-  url: https://github.com/Esri/lerc/archive/js_v{{ version }}.tar.gz
+  url: https://github.com/Esri/lerc/archive/v{{ version }}.tar.gz
   sha256: 1dc090218387ab8ca615eefd844207be64454e37868b396f3e965ed0dcf83947
   # CMakeLists.txt taken from master, and adapted for better compatibility
   # PR made: https://github.com/Esri/lerc/pull/128
@@ -31,10 +29,6 @@ requirements:
     - ninja-base  # [win]
     - m2-patch    # [win]
     - patch       # [unix]
-  host:
-    # TODO: add support for
-    # gdal
-    # geotiff
 
 test:
   commands:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-6447) 
- [Upstream repo](https://github.com/Esri/lerc/tree/v4.0.4)
- release-notes-tagged: https://github.com/Esri/lerc/releases/tag/v4.0.0
- release-diff: https://github.com/Esri/lerc/compare/v3.0...v4.0.0
- requirements-tagged:
  - https://github.com/Esri/lerc/blob/v4.0.0/CMakeLists.txt

### Explanation of changes:

- Add a patch because of missing `#include <climits>`, see https://github.com/Esri/lerc/issues/253
- Add missing shebang `#!/bin/bash` 
- Use ninja-base
- Add more test commands
- Add doc & dev ulrs

### Notes:

- imagecodecs 2024.9.22 requires it https://github.com/AnacondaRecipes/imagecodecs-feedstock/pull/17